### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ devel_isolated/
 CMakeLists.txt.user
 
 srv/_*.py
-*.pcd
 *.pyc
 qtcreator-*
 *.user


### PR DESCRIPTION
.gitignoreから*pcdを削除
ローカルのPCDがファイルはmap_file_localの様なフォルダを各自作成し、そのフォルダを.gitignoreに追加することで対応予定。